### PR TITLE
Add Zig build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Zig build files
+.zig-cache/
+zig-out/
+
+# macOS
+.DS_Store
+
 # =========================
 # Operating System Files
 # =========================

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sac
 Sac is a state-of-the-art lossless audio compression model
 
-Lossless audio compression is a complex problem, because PCM data is highly non-stationary and uses high sample resolution (typically >=16bit). That's why classic context modelling suffers from context dilution problems. Sac employs a simple OLS-NLMS predictor per frame including bias correction. Prediction residuals are encoded using a sophisticated bitplane coder including SSE and various forms of probability estimations. Meta-parameters of the predictor are optimized with [DDS](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2005WR004723) on by-frame basis. This results in a highly asymmetric codec design. 
+Lossless audio compression is a complex problem, because PCM data is highly non-stationary and uses high sample resolution (typically >=16bit). That's why classic context modelling suffers from context dilution problems. Sac employs a simple OLS-NLMS predictor per frame including bias correction. Prediction residuals are encoded using a sophisticated bitplane coder including SSE and various forms of probability estimations. Meta-parameters of the predictor are optimized with [DDS](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2005WR004723) on by-frame basis. This results in a highly asymmetric codec design.
 
 This program wouldn't exist without the help from the following people (in no particular order):
 
@@ -15,7 +15,7 @@ Matt Mahoney, Dmitry Shkarin, Eugene D. Shelwien, Florin Ghido, Grzegorz Ulacha
 
 ## Technical limitations
 Sac uses fp64 for many internal calculations. The change of compiler options or (cpu-)platform might effect the output. Use at your own risk and for testing purposes only.
- 
+
 ## Benchmarks
 **Sac v0.7.7**
 
@@ -60,7 +60,37 @@ Numbers are bits per sample (bps)
 |velvet|9.803|9.990|10.030|10,461|
 |*Mean*|**8.364**|8.493|8.561|8,817|
 
-## Compile
+## Compilation
+
+### Zig
+
+`sac` can be easily built for your system using the Zig build system. Building requires Zig version ≥`0.13.0`.
+
+0. Ensure you have Zig & git installed
+
+1. Clone this repo & enter the cloned directory:
+
+    ```bash
+    git clone https://github.com/MartinEesmaa/sac/
+    cd sac
+    ```
+
+2. Build the binary with Zig:
+
+    ```bash
+    zig build
+    ```
+    > Note: If you'd like to specify a different build target from your host OS/architecture, simply supply the target flag. Example: `zig build -Dtarget=x86_64-linux-gnu`
+
+3. Find the build binary in `zig-out/bin`. You can install it like so:
+
+    ```bash
+    sudo cp zig-out/bin/sac /usr/local/bin
+    ```
+
+Now, you should be all set to use `sac`.
+
+### GCC/G++
 
 To compile SAC audio codec executable program, use for GCC with G++ command by:
 

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+
+    // Create the executable
+    const bin = b.addExecutable(.{
+        .name = "sac",
+        .target = target,
+        .optimize = .ReleaseFast,
+    });
+
+    // List include directories
+    const include_dirs = [_][]const u8{
+        "src/common/",
+        "src/file/",
+        "src/libsac/",
+        "src/model/",
+        "src/opt/",
+        "src/pred/",
+    };
+
+    const cpp_srcs = &[_][]const u8{
+        "src/main.cpp",
+        "src/cmdline.cpp",
+        "src/common/md5.cpp",
+        "src/common/utils.cpp",
+        "src/file/file.cpp",
+        "src/file/sac.cpp",
+        "src/file/wav.cpp",
+        "src/libsac/libsac.cpp",
+        "src/libsac/map.cpp",
+        "src/libsac/pred.cpp",
+        "src/libsac/profile.cpp",
+        "src/libsac/vle.cpp",
+        "src/model/range.cpp",
+        "src/pred/rls.cpp",
+    };
+
+    for (include_dirs) |dir| {
+        bin.addIncludePath(b.path(dir));
+    }
+
+    // Add C++ source files
+    bin.addCSourceFiles(.{
+        .files = cpp_srcs,
+        .flags = &.{
+            "-std=c++11",
+            "-static",
+            "-O3",
+        },
+    });
+
+    // Link libc
+    bin.linkLibCpp();
+    b.installArtifact(bin);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "sac",
+    .version = "1.0.0",
+    .paths = .{""},
+}


### PR DESCRIPTION
Allows for easy cross compilation via specifying a target during the build process